### PR TITLE
Linking issue in Debug builds

### DIFF
--- a/src/openlrr/common.h
+++ b/src/openlrr/common.h
@@ -254,17 +254,6 @@ constexpr auto array_of(T&&... t) -> std::array<V, sizeof...(T)> {
 	flags_enum(name); \
 	assert_sizeof(name, size)
 
-
-namespace Gods98
-{
-	bool Error_IsTraceVisible();
-}
-
-#define log_firstcall() { static bool _log_firstcallbool = false; \
-	if (!_log_firstcallbool) {_log_firstcallbool = true; \
-		if (Gods98::Error_IsTraceVisible()) { \
-			std::printf("%s called\n", __FUNCTION__); } } }
-
 #pragma endregion
 
 

--- a/src/openlrr/engine/core/Errors.h
+++ b/src/openlrr/engine/core/Errors.h
@@ -127,6 +127,11 @@ extern Error_LogLevels errorLogLevels;
 #define Error_LogLoadError(b, s)			do { Gods98::Error_Log(errorGlobs.loadErrorLogFile, (b), "%s\n", (s)); } while (0)
 #define Error_LogRedundantFile(b, s)		do { Gods98::Error_Log(errorGlobs.redundantLogFile, (b), "%s\n", (s)); } while (0)
 
+#define log_firstcall() { static bool _log_firstcallbool = false; \
+	if (!_log_firstcallbool) {_log_firstcallbool = true; \
+		if (Gods98::Error_IsTraceVisible()) { \
+			std::printf("%s called\n", __FUNCTION__); } } }
+
 #pragma endregion
 
 /**********************************************************************************

--- a/src/openlrr/engine/core/Maths.cpp
+++ b/src/openlrr/engine/core/Maths.cpp
@@ -1,6 +1,8 @@
 // Maths.cpp : 
 //
 
+#include "Errors.h"
+
 #include "Maths.h"
 
 

--- a/src/openlrr/engine/core/Wad.cpp
+++ b/src/openlrr/engine/core/Wad.cpp
@@ -2,6 +2,7 @@
 //
 
 #include "../util/Compress.h"
+#include "Errors.h"
 #include "Memory.h"
 
 #include "Wad.h"

--- a/src/openlrr/engine/drawing/Bmp.cpp
+++ b/src/openlrr/engine/drawing/Bmp.cpp
@@ -1,6 +1,7 @@
 // Bmp.cpp : 
 //
 
+#include "../core/Errors.h"
 #include "../core/Memory.h"
 
 #include "Bmp.h"

--- a/src/openlrr/engine/drawing/DirectDraw.cpp
+++ b/src/openlrr/engine/drawing/DirectDraw.cpp
@@ -1047,11 +1047,12 @@ uint32 Gods98::DirectDraw_ToColourFromRGB(IDirectDrawSurface4* surf, uint8 r, ui
 bool Gods98::DirectDraw_FromColourToRGBF(IDirectDrawSurface4* surf, uint32 surfColour, OPTIONAL OUT real32* r, OPTIONAL OUT real32* g, OPTIONAL OUT real32* b, OPTIONAL OUT real32* a)
 {
 	uint8 rbyte, gbyte, bbyte, abyte;
-	DirectDraw_FromColourToRGB(surf, surfColour, &rbyte, &gbyte, &bbyte, &abyte);
+	bool const result = DirectDraw_FromColourToRGB(surf, surfColour, &rbyte, &gbyte, &bbyte, &abyte);
 	if (r) *r = static_cast<real32>(rbyte) / 255.0f;
 	if (g) *g = static_cast<real32>(gbyte) / 255.0f;
 	if (b) *b = static_cast<real32>(bbyte) / 255.0f;
 	if (a) *a = static_cast<real32>(abyte) / 255.0f;
+	return result;
 }
 
 /// CUSTOM: Converts a surface colour value to byte RGB values.

--- a/src/openlrr/engine/input/Keys.cpp
+++ b/src/openlrr/engine/input/Keys.cpp
@@ -1,6 +1,8 @@
 // Keys.cpp : 
 //
 
+#include "../core/Errors.h"
+
 #include "Keys.h"
 
 

--- a/src/openlrr/engine/input/MouseButtons.cpp
+++ b/src/openlrr/engine/input/MouseButtons.cpp
@@ -1,6 +1,8 @@
 // MouseButtons.cpp : 
 //
 
+#include "../core/Errors.h"
+
 #include "MouseButtons.h"
 
 

--- a/src/openlrr/engine/util/Compress.cpp
+++ b/src/openlrr/engine/util/Compress.cpp
@@ -1,6 +1,8 @@
 // Compress.cpp : 
 //
 
+#include "../core/Errors.h"
+
 #include "Compress.h"
 
 

--- a/src/openlrr/engine/util/Registry.cpp
+++ b/src/openlrr/engine/util/Registry.cpp
@@ -2,6 +2,7 @@
 //
 
 #include "../../platform/windows.h"
+#include "../core/Errors.h"
 
 #include "Registry.h"
 

--- a/src/openlrr/engine/video/Animation.cpp
+++ b/src/openlrr/engine/video/Animation.cpp
@@ -8,6 +8,7 @@
 #include "../drawing/DirectDraw.h"
 #include "../drawing/Draw.h"
 #include "../core/Files.h"
+#include "../core/Errors.h"
 #include "../Main.h"
 
 #include "Animation.hpp"

--- a/src/openlrr/engine/video/Animation.cpp
+++ b/src/openlrr/engine/video/Animation.cpp
@@ -7,8 +7,8 @@
 #include "../drawing/Bmp.h"
 #include "../drawing/DirectDraw.h"
 #include "../drawing/Draw.h"
-#include "../core/Files.h"
 #include "../core/Errors.h"
+#include "../core/Files.h"
 #include "../Main.h"
 
 #include "Animation.hpp"

--- a/src/openlrr/engine/video/Movie.cpp
+++ b/src/openlrr/engine/video/Movie.cpp
@@ -3,8 +3,8 @@
 
 #include "../drawing/DirectDraw.h"
 #include "../drawing/Draw.h"
-#include "../core/Files.h"
 #include "../core/Errors.h"
+#include "../core/Files.h"
 #include "../Main.h"
 
 #include "Movie.hpp"

--- a/src/openlrr/engine/video/Movie.cpp
+++ b/src/openlrr/engine/video/Movie.cpp
@@ -4,6 +4,7 @@
 #include "../drawing/DirectDraw.h"
 #include "../drawing/Draw.h"
 #include "../core/Files.h"
+#include "../core/Errors.h"
 #include "../Main.h"
 
 #include "Movie.hpp"

--- a/src/openlrr/game/object/BezierCurve.cpp
+++ b/src/openlrr/game/object/BezierCurve.cpp
@@ -3,6 +3,7 @@
 
 #include "../../engine/Main.h"
 #include "../../engine/core/Maths.h"
+#include "../../engine/core/Errors.h"
 
 #include "BezierCurve.h"
 

--- a/src/openlrr/game/object/BezierCurve.cpp
+++ b/src/openlrr/game/object/BezierCurve.cpp
@@ -2,8 +2,8 @@
 //
 
 #include "../../engine/Main.h"
-#include "../../engine/core/Maths.h"
 #include "../../engine/core/Errors.h"
+#include "../../engine/core/Maths.h"
 
 #include "BezierCurve.h"
 


### PR DESCRIPTION
In Debug builds the linking process failed. This was because of the forward declaration of the inline function `Error_IsTraceVisible`  in `common.h`.
This resulted in the linker expecting to find this symbol from somewhere else, but since it is implemented as inline no actual symbol was generated.
Therefore the macro that this forward declaration required has been moved to the file that actually implements the inline function, therfore solving the linking issue. Though this did resolve in a couple of .cpp requiring an additional include.

Added bonus: a compiler error was fixed in `DirectDraw_FromColourToRGBF` due to it missing an return statement.