### PR TITLE
fix TextMessage resizing issues

### DIFF
--- a/src/openlrr/game/interface/TextMessages.cpp
+++ b/src/openlrr/game/interface/TextMessages.cpp
@@ -83,7 +83,7 @@ void __cdecl LegoRR::Text_Initialise(const char* filename, uint32 x, uint32 y, u
 {
 	textGlobs.msgYPos = y;
 	textGlobs.MsgPanel_Rect1 = *msgRect;
-	textGlobs.winLowPos = Gods98::Font_GetHeight(textGlobs.textOnlyWindow->font);
+	textGlobs.winLowPos = (textGlobs.MsgPanel_Rect1.y + textGlobs.MsgPanel_Rect1.height) - Gods98::Font_GetHeight(textGlobs.textOnlyWindow->font);
 	textGlobs.MsgPanel_Float20 = param_7; // -FC, this seems unused in this code
 	textGlobs.msgXPos = x;
 	Text_UpdatePositionAndSize();

--- a/src/openlrr/game/interface/TextMessages.h
+++ b/src/openlrr/game/interface/TextMessages.h
@@ -119,7 +119,6 @@ void __cdecl Text_Initialise(const char* filename, uint32 x, uint32 y, uint32 un
 void __cdecl Text_UpdatePositionAndSize(void);
 
 // <LegoRR.exe @0046ad50>
-//#define Text_Clear ((void (__cdecl* )(void))0x0046ad50)
 void __cdecl Text_Clear(void);
 
 // <LegoRR.exe @0046ad90>


### PR DESCRIPTION
The formula used for `textGlobs.winLowPos` was incomplete.  
This lead to issues when the MessagePanel was supposed to shrink back down after displaying a long TextMessage.  
Fix was simple, I just added the missing part of the formula, taken from the source dump.

Closes #85