### PR TITLE
fix TextWindow formatting/line splits

### DIFF
--- a/src/openlrr/engine/drawing/TextWindow.cpp
+++ b/src/openlrr/engine/drawing/TextWindow.cpp
@@ -207,9 +207,9 @@ bool32 __cdecl Gods98::TextWindow_Update(TextWindow* window, uint32 posFromEnd, 
 				if ((uint8)c == 203) charWidth = 0;
 				currWidth += charWidth;
 				wordWidth += charWidth;
-				if (currWidth >= window->windowSize.width) {
+				if (currWidth > window->windowSize.width) {
 					// Check to see if the word is longer than the line
-					if (wordWidth >= window->windowSize.width) {
+					if (wordWidth > window->windowSize.width) {
 						// If so, split the word onto the next line
 						window->lineList[window->usedLines] = loop;
 						lineWidthList[window->usedLines-1] = currWidth-charWidth;


### PR DESCRIPTION
Lines equal in length to the window's width limit were split up one word/character too early and did not match the reference from the original LRR. Solved by only splitting lines when their width is **greater than** the window's width limit. 
For more details please read the posts in issue #84.

Closes #84 